### PR TITLE
Add option to search remote repositories for versions

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -3,6 +3,22 @@ Advanced Usage
 
 Some more advanced or non-typical usages of Stac will be outlined below.
 
+Search Remote Repositories
+--------------------------
+
+If the repository you're using is a virtual repository and you want to find the latest version of an
+artifact in one of the repositories being mirrored by it, you'll need to tell the Stac client that it
+should be searching them. Luckily, this is pretty easy.
+
+.. code-block:: python
+
+    import stac.api
+
+    client = stac.api.new_maven_client('https://internal.example.com/artifactory', 'libs-release')
+    version = client.get_latest_version('com.example.services.locations', remote=True)
+    print(version) # '4.0.5'
+
+
 Use HTTP Authentication
 -----------------------
 

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.1.0 - 2016-04-04
+------------------
+* Add optional parameter to :class:`stac.client.ArtifactoryClient` and implementations to
+  allow remote repositories to be searched for the latest version of an artifact.
+
 1.0.1 - 2016-03-09
 ------------------
 * Change :class:`stac.exceptions.NoMatchingVersionsError` to be a subclass of the base

--- a/stac/__init__.py
+++ b/stac/__init__.py
@@ -14,4 +14,4 @@ stac
 Smarter Travel Artifactory Client.
 """
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/stac/http.py
+++ b/stac/http.py
@@ -17,10 +17,8 @@ with this module directly.
 """
 
 from __future__ import absolute_import
-
 # pylint: disable=import-error,no-name-in-module
 import distutils.version
-
 import stac.exceptions
 import stac.util
 
@@ -47,26 +45,28 @@ class VersionApiDao(object):
         self._base_url = base_url
         self._repo = repo
 
-    def get_most_recent_release(self, group, artifact):
+    def get_most_recent_release(self, group, artifact, remote=False):
         """Get the version number of the most recent release (non-integration version)
         of a particular group and artifact combination.
 
         :param str group: Group of the artifact to get the version of
         :param str artifact: Name of the artifact to get the version of
+        :param bool remote: Should remote repositories be searched to find the latest
+            version? Note this can make the request much slower. Default is false.
         :return: Version number of the most recent release
         :rtype: str
         :raises requests.exceptions.HTTPError: For any non-success HTTP responses
             from the Artifactory API.
         """
         url = self._base_url + '/api/search/latestVersion'
-        params = {'g': group, 'a': artifact, 'repos': self._repo}
+        params = {'g': group, 'a': artifact, 'repos': self._repo, 'remote': int(remote)}
         self._logger.debug("Using latest version API at %s - params %s", url, params)
 
         response = self._session.get(url, params=params)
         response.raise_for_status()
         return response.text.strip()
 
-    def get_most_recent_versions(self, group, artifact, limit, integration=False):
+    def get_most_recent_versions(self, group, artifact, limit, remote=False, integration=False):
         """Get a list of the version numbers of the most recent artifacts (integration
         or non-integration), ordered by the version number, for a particular group and
         artifact combination.
@@ -74,6 +74,8 @@ class VersionApiDao(object):
         :param str group: Group of the artifact to get versions of
         :param str artifact: Name of the artifact to get versions of
         :param int limit: Fetch only this many of the most recent releases
+        :param bool remote: Should remote repositories be searched to find the latest
+            versions? Note this can make the request much slower. Default is false.
         :param bool integration: If true, fetch only "integration versions", otherwise
             fetch only non-integration versions.
         :return: Version numbers of the most recent artifacts
@@ -86,7 +88,7 @@ class VersionApiDao(object):
             raise ValueError("Releases limit must be positive")
 
         url = self._base_url + '/api/search/versions'
-        params = {'g': group, 'a': artifact, 'repos': self._repo}
+        params = {'g': group, 'a': artifact, 'repos': self._repo, 'remote': int(remote)}
         self._logger.debug("Using all version API at %s - params %s", url, params)
 
         response = self._session.get(url, params=params)

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -128,7 +128,7 @@ class TestMavenArtifactoryClient(object):
         maven_client = GenericArtifactoryClient(config)
 
         with pytest.raises(ValueError):
-            maven_client.get_latest_versions('com.example.users.service', 0)
+            maven_client.get_latest_versions('com.example.users.service', limit=0)
 
     def test_get_latest_versions_snapshot(self, version_dao, url_generator):
         from stac.client import GenericArtifactoryClient, GenericArtifactoryClientConfig

--- a/test/unit/test_http.py
+++ b/test/unit/test_http.py
@@ -50,7 +50,7 @@ class TestVersionApiClient(object):
         http_client = VersionApiDao(session, 'https://www.example.com/artifactory', 'libs-release')
 
         with pytest.raises(ValueError):
-            http_client.get_most_recent_versions('com.example.services', 'mail', 0)
+            http_client.get_most_recent_versions('com.example.services', 'mail', remote=False, limit=0)
 
     def test_get_most_recent_versions_no_results(self, session, response):
         from stac.http import VersionApiDao
@@ -64,7 +64,7 @@ class TestVersionApiClient(object):
         http_client = VersionApiDao(session, 'https://www.example.com/artifactory', 'libs-release')
 
         with pytest.raises(requests.HTTPError):
-            http_client.get_most_recent_versions('com.example.services', 'mail', 3)
+            http_client.get_most_recent_versions('com.example.services', 'mail', remote=False, limit=3)
 
     def test_get_most_recent_versions_no_integration_results(self, session, response):
         from stac.http import VersionApiDao
@@ -91,7 +91,8 @@ class TestVersionApiClient(object):
         session.get.return_value = response
 
         http_client = VersionApiDao(session, 'https://www.example.com/artifactory', 'libs-release')
-        versions = http_client.get_most_recent_versions('com.example.services', 'mail', 2, integration=True)
+        versions = http_client.get_most_recent_versions(
+            'com.example.services', 'mail', remote=False, limit=2, integration=True)
         assert 0 == len(versions)
 
     def test_get_most_recent_versions_no_non_integration_results(self, session, response):
@@ -119,7 +120,8 @@ class TestVersionApiClient(object):
         session.get.return_value = response
 
         http_client = VersionApiDao(session, 'https://www.example.com/artifactory', 'libs-snapshot')
-        versions = http_client.get_most_recent_versions('com.example.services', 'mail', 2, integration=False)
+        versions = http_client.get_most_recent_versions(
+            'com.example.services', 'mail', remote=False, limit=2, integration=False)
         assert 0 == len(versions)
 
     def test_get_most_recent_versions(self, session, response):
@@ -147,7 +149,8 @@ class TestVersionApiClient(object):
         session.get.return_value = response
 
         http_client = VersionApiDao(session, 'https://www.example.com/artifactory', 'libs-snapshot')
-        versions = http_client.get_most_recent_versions('com.example.services', 'mail', 2, integration=True)
+        versions = http_client.get_most_recent_versions(
+            'com.example.services', 'mail', remote=False, limit=2, integration=True)
 
         assert 2 == len(versions)
         assert '4.441-SNAPSHOT' == versions[0]


### PR DESCRIPTION
Add keyword (optional) argument to the client interface to allow searching remote repos
such as when the repository being interacted with is a virtual repository. This will default
to false to preserve the existing behavior and performance.

Fixes #3